### PR TITLE
Support presentation remote history navigation

### DIFF
--- a/src/components/TranscriptionRoom.jsx
+++ b/src/components/TranscriptionRoom.jsx
@@ -1845,10 +1845,28 @@ const TranscriptionRoom = ({ initialService }) => {
     const handleHistoryShortcut = (event) => {
       if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
       if (isEditableShortcutTarget(event.target)) return;
-      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+
+      const shortcutOffsets = {
+        ArrowLeft: -1,
+        ArrowUp: -1,
+        PageUp: -1,
+        ArrowRight: 1,
+        ArrowDown: 1,
+        PageDown: 1
+      };
+      const legacyShortcutOffsets = {
+        33: -1, // PageUp
+        37: -1, // ArrowLeft
+        38: -1, // ArrowUp
+        34: 1, // PageDown
+        39: 1, // ArrowRight
+        40: 1 // ArrowDown
+      };
+      const offset = shortcutOffsets[event.key] ?? shortcutOffsets[event.code] ?? legacyShortcutOffsets[event.keyCode];
+      if (!offset) return;
 
       event.preventDefault();
-      selectHistoryByOffset(event.key === 'ArrowLeft' ? -1 : 1);
+      selectHistoryByOffset(offset);
     };
 
     window.addEventListener('keydown', handleHistoryShortcut);


### PR DESCRIPTION
## Summary
- map presentation remote Up/PageUp keys to history Prev
- map presentation remote Down/PageDown keys to history Next
- keep Left/Right support and add legacy keyCode fallback for Bluetooth remotes
- prevent default page scrolling when a history shortcut is handled

## Verification
- `npm run build`

Note: build succeeds with existing ESLint warnings unrelated to this change.
